### PR TITLE
 Update code to make use of generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Next
 [![GoDoc](https://godoc.org/klaidliadon.dev/next?status.svg)](https://godoc.org/klaidliadon.dev/next)
 [![Build Status](https://travis-ci.org/klaidliadon/next.svg?branch=master)](https://travis-ci.org/klaidliadon/next) 
-[![codecov.io](http://codecov.io/github/klaidliadon/next/coverage.svg?branch=master)](http://codecov.io/github/klaidliadon/next?branch=master)
+[![codecov.io](https://codecov.io/github/klaidliadon/next/coverage.svg?branch=master)](https://codecov.io/github/klaidliadon/next?branch=master)
 
 The package calculates asynchronously combinations and permutations of a collection of values.
 
 To add the package recommended:
 
-	go get klaidliadon.dev/next
+```sh
+go get klaidliadon.dev/next
+```
 
 ## Functionalities
 
@@ -20,31 +22,35 @@ To add the package recommended:
 
 Just use create a new channel using `Combination()` or `Permutation()` and receive the results.
 
-	package main
-	
-	import (
-		"fmt"
-		"klaidliadon.dev/next"
-	)
-	
-	func main() {
-		for v := range next.Combination([]interface{}{1,2,3,4}, 2, true) {
-			fmt.Println(v)
-		}
+```go
+package main
+
+import (
+	"fmt"
+	"klaidliadon.dev/next"
+)
+
+func main() {
+	for v := range next.Combination([]int{1,2,3,4}, 2, true) {
+		fmt.Println(v)
 	}
+}
+```
 
 Produces
 
-	[1 1]
-	[1 2]
-	[1 3]
-	[1 4]
-	[2 2]
-	[2 3]
-	[2 4]
-	[3 3]
-	[3 4]
-	[4 4]
+```
+[1 1]
+[1 2]
+[1 3]
+[1 4]
+[2 2]
+[2 3]
+[2 4]
+[3 3]
+[3 4]
+[4 4]
+```
 
 ## Roadmap
 

--- a/combination.go
+++ b/combination.go
@@ -26,7 +26,7 @@ func (c combination[T]) of(r int) <-chan []T {
 func (c combination[T]) results(r int, ch chan<- []T) {
 	defer close(ch)
 	base := c
-	n, t := len(c), count[T](c, r)
+	n, t := len(c), count(c, r)
 	if t == 0 {
 		return
 	}
@@ -66,7 +66,7 @@ func (c repeatCombination[T]) of(r int) <-chan []T {
 func (c repeatCombination[T]) results(r int, ch chan<- []T) {
 	defer close(ch)
 	base := []T(c)
-	n, t := len(c), count[T](c, r)
+	n, t := len(c), count(c, r)
 	idxs := make([]int, r)
 	sendIndex(base, idxs, ch)
 	for i, j := 1, r-1; i < t; i++ {

--- a/combination.go
+++ b/combination.go
@@ -1,32 +1,32 @@
 package next
 
 // Returns a channel of combinantions of n element from base w/o repetition
-func Combination(base []interface{}, n int, repeat bool) <-chan []interface{} {
+func Combination[T any](base []T, n int, repeat bool) <-chan []T {
 	if n < 0 {
 		n = 0
 	}
 	if repeat {
-		return repeatCombination(base).of(n)
+		return repeatCombination[T](base).of(n)
 	} else {
-		return combination(base).of(n)
+		return combination[T](base).of(n)
 	}
 }
 
 // A collection of elements for calculating combinations.
-type combination []interface{}
+type combination[T any] []T
 
 // Returns a channel of possible combinations of r elements.
-func (c combination) of(r int) <-chan []interface{} {
-	res := make(chan []interface{})
+func (c combination[T]) of(r int) <-chan []T {
+	res := make(chan []T)
 	go c.results(r, res)
 	return res
 }
 
 // Calculates the results and send them back to the channel.
-func (c combination) results(r int, ch chan<- []interface{}) {
+func (c combination[T]) results(r int, ch chan<- []T) {
 	defer close(ch)
-	base := []interface{}(c)
-	n, t := len(c), count(c, r)
+	base := c
+	n, t := len(c), count[T](c, r)
 	if t == 0 {
 		return
 	}
@@ -54,19 +54,19 @@ func (c combination) results(r int, ch chan<- []interface{}) {
 }
 
 // A collection of elements for calculating combinations.
-type repeatCombination []interface{}
+type repeatCombination[T any] []T
 
-func (c repeatCombination) of(r int) <-chan []interface{} {
-	res := make(chan []interface{})
+func (c repeatCombination[T]) of(r int) <-chan []T {
+	res := make(chan []T)
 	go c.results(r, res)
 	return res
 }
 
 // Calculates the results and send them back to the channel.
-func (c repeatCombination) results(r int, ch chan<- []interface{}) {
+func (c repeatCombination[T]) results(r int, ch chan<- []T) {
 	defer close(ch)
-	base := []interface{}(c)
-	n, t := len(c), count(c, r)
+	base := []T(c)
+	n, t := len(c), count[T](c, r)
 	idxs := make([]int, r)
 	sendIndex(base, idxs, ch)
 	for i, j := 1, r-1; i < t; i++ {

--- a/common.go
+++ b/common.go
@@ -2,13 +2,13 @@ package next
 
 import "math"
 
-type base interface {
-	of(int) <-chan []interface{}
+type base[T any] interface {
+	of(int) <-chan []T
 }
 
-func count(b base, r int) int {
+func count[T any](b base[T], r int) int {
 	switch c := b.(type) {
-	case combination:
+	case combination[T]:
 		n := len(c)
 		if r > n {
 			return 0
@@ -18,7 +18,7 @@ func count(b base, r int) int {
 			t = t * (n - r + i) / i
 		}
 		return t
-	case permutation:
+	case permutation[T]:
 		n := len(c)
 		if r > n {
 			return 0
@@ -28,7 +28,7 @@ func count(b base, r int) int {
 			t = t * i
 		}
 		return t
-	case repeatCombination:
+	case repeatCombination[T]:
 		n := len(c)
 		var t = 1
 		for i := r + 1; i < n+r; i++ {
@@ -38,16 +38,16 @@ func count(b base, r int) int {
 			t = t / i
 		}
 		return t
-	case repeatPermutation:
+	case repeatPermutation[T]:
 		return int(math.Pow(float64(len(c)), float64(r)))
 	}
 	return 0
 }
 
 // Creates a new result using the selected indexes and sends them to the channel
-func sendIndex(base []interface{}, index []int, ch chan<- []interface{}) {
+func sendIndex[T any](base []T, index []int, ch chan<- []T) {
 	r := len(index)
-	res := make([]interface{}, r)
+	res := make([]T, r)
 	for i, idx := range index {
 		res[i] = base[idx]
 	}

--- a/common_test.go
+++ b/common_test.go
@@ -23,7 +23,7 @@ func newCases(n int) []base[string] {
 }
 
 func TestUnknown(t *testing.T) {
-	if c := count[testbase](testbase(false), 2); c != 0 {
+	if c := count(testbase(false), 2); c != 0 {
 		t.Fail()
 	}
 }

--- a/common_test.go
+++ b/common_test.go
@@ -1,26 +1,29 @@
 package next
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 type testbase bool
 
-func (t testbase) of(int) <-chan []interface{} { return nil }
+func (t testbase) of(int) <-chan []testbase { return nil }
 
-func newCases(n int) []base {
-	b := make([]interface{}, n)
+func newCases(n int) []base[string] {
+	b := make([]string, n)
 	for i := range b {
-		b[i] = string('a' + i)
+		b[i] = fmt.Sprintf("a%d", i)
 	}
-	return []base{
-		combination(b[:]),
-		permutation(b[:]),
-		repeatCombination(b[:]),
-		repeatPermutation(b[:]),
+	return []base[string]{
+		combination[string](b[:]),
+		permutation[string](b[:]),
+		repeatCombination[string](b[:]),
+		repeatPermutation[string](b[:]),
 	}
 }
 
 func TestUnknown(t *testing.T) {
-	if c := count(testbase(false), 2); c != 0 {
+	if c := count[testbase](testbase(false), 2); c != 0 {
 		t.Fail()
 	}
 }
@@ -45,7 +48,7 @@ func TestSizes(t *testing.T) {
 }
 
 func TestCreation(t *testing.T) {
-	base := []interface{}{1, 2, 3}
+	base := []int{1, 2, 3}
 	Combination(base, 2, false)
 	Combination(base, -1, true)
 	Permutation(base, 2, false)
@@ -56,7 +59,7 @@ func TestShowcase(t *testing.T) {
 	size := 5
 	cases := newCases(size)
 	for _, c := range cases {
-		var r = make([][]interface{}, 0, count(c, size))
+		var r = make([][]string, 0, count(c, size))
 		for v := range c.of(3) {
 			r = append(r, v)
 		}

--- a/doc.go
+++ b/doc.go
@@ -11,7 +11,7 @@
 		)
 
 		func main() {
-			for v := range next.Combination([]interface{1,2,3,4}, 2, true) {
+			for v := range next.Combination([]int{1,2,3,4}, 2, true) {
 				fmt.Println(v)
 			}
 		}

--- a/go-next/main.go
+++ b/go-next/main.go
@@ -17,10 +17,8 @@ func main() {
 	flag.BoolVar(&r, "repeat", false, "repeatition")
 	flag.UintVar(&s, "size", 0, "size of each result (not 0)")
 	flag.Parse()
-	var args []interface{}
-	for _, v := range flag.Args() {
-		args = append(args, v)
-	}
+	args := flag.Args()
+	
 	if s == 0 {
 		flag.Usage()
 		os.Exit(1)
@@ -29,7 +27,7 @@ func main() {
 		fmt.Printf("%s: please specify at least an element.\n", os.Args[0])
 		os.Exit(1)
 	}
-	var ch <-chan []interface{}
+	var ch <-chan []string
 	if o {
 		ch = next.Permutation(args, int(s), r)
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module klaidliadon.dev/next
 
-go 1.13
+go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module klaidliadon.dev/next
 
-go 1.18
+go 1.21

--- a/permutation.go
+++ b/permutation.go
@@ -1,28 +1,28 @@
 package next
 
 // Returns a channel of permutations of n element from base w/o repetition
-func Permutation(base []interface{}, n int, repeat bool) <-chan []interface{} {
+func Permutation[T any](base []T, n int, repeat bool) <-chan []T {
 	if n < 0 {
 		n = 0
 	}
 	if repeat {
-		return repeatPermutation(base).of(n)
+		return repeatPermutation[T](base).of(n)
 	} else {
-		return permutation(base).of(n)
+		return permutation[T](base).of(n)
 	}
 }
 
 // A combination of elements.
-type permutation []interface{}
+type permutation[T any] []T
 
 // Returns a channel of possible combinations of l elements.
-func (p permutation) of(r int) <-chan []interface{} {
-	res := make(chan []interface{})
+func (p permutation[T]) of(r int) <-chan []T {
+	res := make(chan []T)
 	go p.results(r, res)
 	return res
 }
 
-func (p permutation) results(r int, ch chan<- []interface{}) {
+func (p permutation[T]) results(r int, ch chan<- []T) {
 	defer close(ch)
 	n := len(p)
 	if r > n {
@@ -36,8 +36,8 @@ func (p permutation) results(r int, ch chan<- []interface{}) {
 	for i := range cycles {
 		cycles[i] = n - i
 	}
-	cmb := make([]interface{}, r)
-	res := make([]interface{}, r)
+	cmb := make([]T, r)
+	res := make([]T, r)
 	for i, el := range idxs[:r] {
 		cmb[i] = p[el]
 	}
@@ -60,7 +60,7 @@ func (p permutation) results(r int, ch chan<- []interface{}) {
 				for k := i; k < r; k += 1 {
 					cmb[k] = p[idxs[k]]
 				}
-				res := make([]interface{}, r)
+				res := make([]T, r)
 				copy(res, cmb)
 				ch <- res
 				break
@@ -74,20 +74,20 @@ func (p permutation) results(r int, ch chan<- []interface{}) {
 }
 
 // A combination of elements.
-type repeatPermutation []interface{}
+type repeatPermutation[T any] []T
 
 // Returns a channel of possible combinations of l elements.
-func (p repeatPermutation) of(r int) <-chan []interface{} {
-	res := make(chan []interface{})
+func (p repeatPermutation[T]) of(r int) <-chan []T {
+	res := make(chan []T)
 	go p.results(r, res)
 	return res
 }
 
-func (p repeatPermutation) results(r int, ch chan<- []interface{}) {
+func (p repeatPermutation[T]) results(r int, ch chan<- []T) {
 	defer close(ch)
-	n, t := len(p), count(p, r)
+	n, t := len(p), count[T](p, r)
 	for i := 0; i < t; i++ {
-		v := make([]interface{}, r)
+		v := make([]T, r)
 		j := i
 		for k := 0; k < r; k++ {
 			x := j % n

--- a/permutation.go
+++ b/permutation.go
@@ -85,7 +85,7 @@ func (p repeatPermutation[T]) of(r int) <-chan []T {
 
 func (p repeatPermutation[T]) results(r int, ch chan<- []T) {
 	defer close(ch)
-	n, t := len(p), count[T](p, r)
+	n, t := len(p), count(p, r)
 	for i := 0; i < t; i++ {
 		v := make([]T, r)
 		j := i


### PR DESCRIPTION
* Update code to make use of generics - requires Go 1.21+ (can revert 2nd commit to require just 1.18 if needed)
    * base arguments to functions can still be of `[]interface{}` type, but now it can be a slice of any type
* Update examples (& add syntax highlighting in readme.md)
* simplify main.go since `[]interface{}` conversion is no longer needed


I'd like to ask you to create a new tagged version sometime, so I can import e.g version `v1.1.0` instead of `v0.0.0-20190920153227-ed266f1ab94f`